### PR TITLE
provide versioned vpack files for later reference

### DIFF
--- a/tmp/Time/vvvv-Time.vpack
+++ b/tmp/Time/vvvv-Time.vpack
@@ -1,0 +1,18 @@
+<vpack>
+  <meta>
+    <name>vvvv-Time</name>
+    <source>https://github.com/letmp/vvvv-Time</source>
+    <author>tmp</author>
+  </meta>
+  <install>
+    Download(
+      "https://vvvv.org/sites/all/modules/general/pubdlcnt/pubdlcnt.php?file=https://vvvv.org/sites/default/files/uploads/vvvv-time_0.5.5_45beta33.3_x64.zip",
+      VPM.TempDir + "\\vvvv-Time.zip"
+    );
+    Extract(VPM.TempDir + "\\vvvv-Time.zip", Pack.TempDir);
+	  CopyDir(
+	    Pack.TempDir,
+	    VVVV.Dir
+	  );
+  </install>
+</vpack>

--- a/velcrome/Message/vvvv-Message.2.8.4.vpack
+++ b/velcrome/Message/vvvv-Message.2.8.4.vpack
@@ -1,0 +1,28 @@
+<vpack>
+  <meta>
+    <name>vvvv-Message</name>
+    <source>https://github.com/velcrome/vvvv-Message</source>
+    <author>velcrome</author>
+      <dependencies>
+        <dependency>
+          <name>dx11-vvvv</name>
+          <source>vpms://raw.githubusercontent.com/vvvvpm/vpdb/master/vux/dx11-vvvv/github.master.vpack</source>
+        </dependency>
+        <!--dependency>
+          <name>vvvv-Time</name>
+          <source>vpms://raw.githubusercontent.com/vvvvpm/vpdb/master/tmp/Time/vvvv-Time.vpack</source>
+        </dependency-->
+      </dependencies>
+      </meta>
+  <install>
+    Download(
+      "https://github.com/velcrome/vvvv-Message/releases/download/2.8.4/vvvv-Message.zip",
+      VPM.TempDir + "\\vvvv-Message.zip"
+    );
+    Extract(VPM.TempDir + "\\vvvv-Message.zip", Pack.TempDir + "\\extract");
+    CopyDir(
+      Pack.TempDir + "\\extract",
+      VVVV.Dir + "\\packs\\vvvv-Message"
+    );
+  </install>
+</vpack>

--- a/vux/dx11-vvvv/dx11-vvvv.0.7.1.vpack
+++ b/vux/dx11-vvvv/dx11-vvvv.0.7.1.vpack
@@ -1,0 +1,18 @@
+<vpack>
+	<meta>
+		<name>dx11-vvvv</name>
+		<author>vux</author>
+        <aliases>dx11, vvvv-dx11</aliases>
+    </meta>
+    <install>
+      Download(
+        "https://vvvv.org/sites/all/modules/general/pubdlcnt/pubdlcnt.php?file=https://vvvv.org/sites/default/files/uploads/vvvv-packs-dx11-0.7.1-x64.zip",
+        VPM.TempDir + "\\dx11-vvvv.zip"
+      );
+      Extract(VPM.TempDir + "\\dx11-vvvv.zip", Pack.TempDir);
+      CopyDir(
+        Pack.TempDir,
+        VVVV.Dir
+      );
+    </install>
+</vpack>


### PR DESCRIPTION
I was thinking, 

maybe vpdb is a cool place to save fully versioned vpack files, something like a repository of long gone iterations?

With a good workflow of people adding their own vpack file to their projects, and keeping them up to date, maybe it is wise to drop a vpack copy here every now and then?